### PR TITLE
Raise error on invalid serializer.

### DIFF
--- a/apc.c
+++ b/apc.c
@@ -131,8 +131,6 @@ PHP_APCU_API apc_serializer_t* apc_find_serializer(const char* name) {
 		}
 	}
 
-	php_error_docref(NULL, E_WARNING, "apc_find_serializer: serializer \"%s\" does not registered.", name);
-
 	return NULL;
 } /* }}} */
 

--- a/apc.c
+++ b/apc.c
@@ -130,6 +130,9 @@ PHP_APCU_API apc_serializer_t* apc_find_serializer(const char* name) {
 			return serializer;
 		}
 	}
+
+	php_error_docref(NULL, E_WARNING, "apc_find_serializer: serializer \"%s\" does not registered.", name);
+
 	return NULL;
 } /* }}} */
 

--- a/apc.c
+++ b/apc.c
@@ -130,7 +130,6 @@ PHP_APCU_API apc_serializer_t* apc_find_serializer(const char* name) {
 			return serializer;
 		}
 	}
-
 	return NULL;
 } /* }}} */
 

--- a/apc_cache.c
+++ b/apc_cache.c
@@ -1219,7 +1219,7 @@ PHP_APCU_API void apc_cache_serializer(apc_cache_t* cache, const char* name) {
 	if (cache && !cache->serializer) {
 		cache->serializer = apc_find_serializer(name);
 		if (strcmp(name, "default") != 0 && !cache->serializer) {
-			php_error_docref(NULL, E_WARNING, "apc_find_serializer: serializer \"%s\" does not registered.", name);
+			php_error_docref(NULL, E_WARNING, "apc_find_serializer: serializer \"%s\" is not supported.", name);
 		}
 	}
 } /* }}} */

--- a/apc_cache.c
+++ b/apc_cache.c
@@ -1218,6 +1218,9 @@ PHP_APCU_API zend_bool apc_cache_defense(apc_cache_t *cache, zend_string *key, t
 PHP_APCU_API void apc_cache_serializer(apc_cache_t* cache, const char* name) {
 	if (cache && !cache->serializer) {
 		cache->serializer = apc_find_serializer(name);
+		if (strcmp(name, "default") != 0 && !cache->serializer) {
+			php_error_docref(NULL, E_WARNING, "apc_find_serializer: serializer \"%s\" does not registered.", name);
+		}
 	}
 } /* }}} */
 

--- a/apc_cache.c
+++ b/apc_cache.c
@@ -1219,7 +1219,7 @@ PHP_APCU_API void apc_cache_serializer(apc_cache_t* cache, const char* name) {
 	if (cache && !cache->serializer) {
 		cache->serializer = apc_find_serializer(name);
 		if (strcmp(name, "default") != 0 && !cache->serializer) {
-			php_error_docref(NULL, E_WARNING, "apc_find_serializer: serializer \"%s\" is not supported.", name);
+			php_error_docref(NULL, E_WARNING, "apc_cache_serializer: serializer \"%s\" is not supported.", name);
 		}
 	}
 } /* }}} */

--- a/tests/serializer_invalid.phpt
+++ b/tests/serializer_invalid.phpt
@@ -1,0 +1,14 @@
+--TEST--
+Serializer: invalid pattern.
+--SKIPIF--
+<?php require_once(dirname(__FILE__) . '/skipif.inc'); ?>
+--INI--
+apc.enabled=1
+apc.enable_cli=1
+apc.serializer=igbinary
+--FILE--
+<?php
+--EXPECT--
+Warning: PHP Startup: apc_find_serializer: serializer "igbinary" does not registered. in Unknown on line 0
+
+Warning: Unknown: apc_find_serializer: serializer "igbinary" does not registered. in Unknown on line 0

--- a/tests/serializer_invalid.phpt
+++ b/tests/serializer_invalid.phpt
@@ -9,6 +9,4 @@ apc.serializer=igbinary
 --FILE--
 <?php
 --EXPECT--
-Warning: PHP Startup: apc_find_serializer: serializer "igbinary" does not registered. in Unknown on line 0
-
 Warning: Unknown: apc_find_serializer: serializer "igbinary" does not registered. in Unknown on line 0

--- a/tests/serializer_invalid.phpt
+++ b/tests/serializer_invalid.phpt
@@ -9,4 +9,4 @@ apc.serializer=igbinary
 --FILE--
 <?php
 --EXPECT--
-Warning: Unknown: apc_find_serializer: serializer "igbinary" is not supported. in Unknown on line 0
+Warning: Unknown: apc_cache_serializer: serializer "igbinary" is not supported. in Unknown on line 0

--- a/tests/serializer_invalid.phpt
+++ b/tests/serializer_invalid.phpt
@@ -9,4 +9,4 @@ apc.serializer=igbinary
 --FILE--
 <?php
 --EXPECT--
-Warning: Unknown: apc_find_serializer: serializer "igbinary" does not registered. in Unknown on line 0
+Warning: Unknown: apc_find_serializer: serializer "igbinary" is not supported. in Unknown on line 0

--- a/tests/serializer_valid.phpt
+++ b/tests/serializer_valid.phpt
@@ -1,0 +1,11 @@
+--TEST--
+Serializer: valid pattern.
+--SKIPIF--
+<?php require_once(dirname(__FILE__) . '/skipif.inc'); ?>
+--INI--
+apc.enabled=1
+apc.enable_cli=1
+apc.serializer=php
+--FILE--
+<?php
+--EXPECT--


### PR DESCRIPTION
APCu will implicitly use the default serializer if an invalid serializer is specified.

It fix so that it raise an error if an invalid serializer.